### PR TITLE
Make npm package work directly from github

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "url": "https://github.com/valtech-sd/amqp-cacoon.git"
   },
   "scripts": {
+    "prepare": "rimraf ./build && tsc",
     "build": "rimraf ./build && tsc",
     "test": "rimraf ./build && tsc && mocha --exit -r ts-node/register ./tests/**/*.test.ts"
   },


### PR DESCRIPTION
- Add npm prepare script to make this work directly from the repository without the need for an npm registry