### PR TITLE
Fix consumer cancel semantics and add shared-connection 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,21 +32,20 @@ Please note we have a code of conduct, please follow it in all your interactions
 
 **Note:** Be sure to follow our [Code of Conduct](link-to-code-of-conduct) and [Contributor License Agreement](link-to-CLA) if we have one.
 
-## Releases and Semantic Versioning
+## Releases and Versioning
 
-We use GitHub's releases feature and semantic versioning for managing releases for our project. Here's how to create releases and use specific version tags for working with npm semantic versioning:
+We manage releases manually using GitHub Releases and semantic versioning.
 
-1. To create a new release, go to the "Releases" tab in the GitHub repository.
+When preparing a release, update the version in `package.json` to the intended semver value before creating the release tag. The GitHub release tag should match the package version (for example, `package.json` version `3.4.0` should be released with tag `v3.4.0`).
+1. Update the version in `package.json`.
+2. Confirm any release notes or documentation updates that should ship with the release.
+3. Go to the "Releases" tab in the GitHub repository.
+4. Click on the "Draft a new release" button.
+5. In the "Tag version" field, enter the matching semver-formatted tag (for example, `v1.0.0`).
+6. Enter a release title and description to provide details about this release.
+7. Click "Publish release" to create the release.
 
-2. Click on the "Draft a new release" button.
-
-3. In the "Tag version" field, enter your specific semver-formatted tag (e.g., v1.0.0) for the release.
-
-4. Enter a release title and description to provide details about this release.
-
-5. Click "Publish release" to create the release.
-
-With this process, we ensure that every release in this project corresponds to a semantic versioning tag and a corresponding release on GitHub.
+This keeps the published package version and GitHub release tag aligned.
 
 Thank you for your interest in contributing to [Your Project Name]!
 

--- a/README.md
+++ b/README.md
@@ -321,20 +321,27 @@ To run the examples:
 
 ## Running Tests for this Repo
 
-Note that all the tests for this REPO are UNIT TESTS that do not require an actual AMQP host to be
-setup. Consequently, the tests verify that the AMQP Cacoon wrappers are properly calling the underlying
-AMQPLIP and NODE AMQP MANAGER libraries. For a more "real world" test, see [Run the Examples](#run-the-examples).
+This repo has both unit tests and Docker-backed e2e tests against a real RabbitMQ broker.
 
 1. Install node modules (This also loads local modules from our own repositories)
 
    ```bash
    npm install
    ```
-1. Run tests
+1. Run unit tests
 
    ```bash
    npm run test
    ```
+1. Run the e2e test suite
+
+   ```bash
+   npm run test:e2e
+   ```
+
+`npm run test:e2e` starts RabbitMQ with Docker Compose at the beginning of the suite and tears it down when the suite finishes. The `test:e2e:up` and `test:e2e:down` scripts are still available if you want to inspect the broker manually while debugging.
+
+The e2e suite currently verifies graceful shutdown, backlog preservation during shutdown with `prefetch: 1`, and reconnect behavior for both consumers and queued publishes.
 
 ## Roadmap 
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,8 @@
   <img height='300' src="./assets/amqp_cacoon_2.png">
 </p>
 
-[![CircleCI](https://circleci.com/gh/valtech-sd/amqp-cacoon.svg?style=svg)](https://circleci.com/gh/valtech-sd/amqp-cacoon)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![TypeScript](https://badges.frapsoft.com/typescript/code/typescript.svg)](https://github.com/ellerbrock/typescript-badges/)
-[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
 ## Overview
 

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -1,0 +1,14 @@
+services:
+  rabbitmq:
+    image: rabbitmq:3-management
+    ports:
+      - "5673:5672"
+      - "15673:15672"
+    environment:
+      RABBITMQ_DEFAULT_USER: guest
+      RABBITMQ_DEFAULT_PASS: guest
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 12

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amqp-cacoon",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "description": "AmqpCacoon is an abstraction around amqplib that provides a simple interface with flow control included out of the box",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,11 @@
   "scripts": {
     "prepare": "rimraf ./build && tsc",
     "build": "rimraf ./build && tsc",
-    "test": "rimraf ./build && tsc && mocha --exit -r ts-node/register ./tests/**/*.test.ts"
+    "test": "npm run test:unit",
+    "test:unit": "rimraf ./build && tsc && mocha --exit -r ts-node/register ./tests/unit/**/*.test.ts",
+    "test:e2e": "rimraf ./build && tsc && mocha --exit -r ts-node/register ./tests/e2e/**/*.test.ts",
+    "test:e2e:up": "docker compose -f docker-compose.e2e.yml up -d",
+    "test:e2e:down": "docker compose -f docker-compose.e2e.yml down -v"
   },
   "dependencies": {
     "amqp-connection-manager": "~4.1.14",

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,9 @@ export interface ConsumeBatchMessages {
 }
 
 // Used for registerConsumer function
-export interface ConsumerOptions extends Options.Consume {}
+export interface ConsumerOptions extends Options.Consume {
+  prefetch?: number;
+}
 
 // Used for registerConsumerBatch function
 export interface ConsumerBatchOptions extends Options.Consume {
@@ -254,15 +256,11 @@ class AmqpCacoon {
     try {
       // Get consumer channel
       const channelWrapper = await this.getConsumerChannel();
-
-      channelWrapper.addSetup((channel: Channel) => {
-        // Register a consume on the current channel
-        return channel.consume(
-          queue,
-          consumerHandler.bind(this, channelWrapper),
-          options,
-        );
-      });
+      await channelWrapper.consume(
+        queue,
+        consumerHandler.bind(this, channelWrapper),
+        options,
+      );
     } catch (e) {
       if (this.logger)
         this.logger.error("AMQPCacoon.registerConsumerPrivate: Error: ", e);

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,6 +68,7 @@ export interface IAmqpCacoonConfig {
   providers: {
     logger?: ILogger;
   };
+  shareConnection?: boolean;
   onChannelConnect?: ConnectCallback;
   onBrokerConnect?: BrokerConnectCallback;
   onBrokerDisconnect?: BrokerDisconnectCallback;
@@ -86,16 +87,30 @@ globalThis.amqpCacoonConnections = [];
  * 4. When consuming the callback registered in the previous step will be called when a message is received
  **/
 class AmqpCacoon {
+  private static sharedConnections: {
+    [key: string]: {
+      connection: AmqpConnectionManager;
+      refCount: number;
+    };
+  } = {};
   private pubChannelWrapper: ChannelWrapper | null;
   private subChannelWrapper: ChannelWrapper | null;
   private connection?: AmqpConnectionManager;
   private fullHostName: string;
   private amqp_opts: object;
+  private shareConnection: boolean;
+  private sharedConnectionKey: string | null;
   private logger?: ILogger;
   // private maxWaitForDrainMs: number;
   private onChannelConnect: ConnectCallback | null;
   private onBrokerConnect: Function | null;
   private onBrokerDisconnect: Function | null;
+  private hasInjectedConnectionEvents: boolean = false;
+  private readonly brokerConnectHandler: (
+    connection: Connection,
+    url: string,
+  ) => void;
+  private readonly brokerDisconnectHandler: (err: Error) => void;
   private isShuttingDownPublisher: boolean = false;
   private isShuttingDownConsumer: boolean = false;
   private hasCanceledConsumer: boolean = false;
@@ -121,11 +136,15 @@ class AmqpCacoon {
     this.fullHostName =
       config.connectionString || AmqpCacoon.getFullHostName(config);
     this.amqp_opts = config.amqp_opts;
+    this.shareConnection = config.shareConnection || false;
+    this.sharedConnectionKey = this.shareConnection ? this.fullHostName : null;
     this.logger = config.providers.logger;
     // this.maxWaitForDrainMs = config.maxWaitForDrainMs || 60000; // Default to 1 min
     this.onChannelConnect = config.onChannelConnect || null;
     this.onBrokerConnect = config.onBrokerConnect || null;
     this.onBrokerDisconnect = config.onBrokerDisconnect || null;
+    this.brokerConnectHandler = this.handleBrokerConnect.bind(this);
+    this.brokerDisconnectHandler = this.handleBrokerDisconnect.bind(this);
 
     // Add this instance to the global list of connections
     globalThis.amqpCacoonConnections.push(this);
@@ -152,9 +171,72 @@ class AmqpCacoon {
   }
 
   private injectConnectionEvents(connection: AmqpConnectionManager) {
+    if (this.hasInjectedConnectionEvents) return;
     // Subscribe to onConnect / onDisconnection functions for debugging
-    connection.on("connect", this.handleBrokerConnect.bind(this));
-    connection.on("disconnect", this.handleBrokerDisconnect.bind(this));
+    connection.on("connect", this.brokerConnectHandler);
+    connection.on("disconnect", this.brokerDisconnectHandler);
+    this.hasInjectedConnectionEvents = true;
+  }
+
+  private removeConnectionEvents(connection: AmqpConnectionManager) {
+    if (!this.hasInjectedConnectionEvents) return;
+    connection.removeListener("connect", this.brokerConnectHandler);
+    connection.removeListener("disconnect", this.brokerDisconnectHandler);
+    this.hasInjectedConnectionEvents = false;
+  }
+
+  private getOrCreateConnection() {
+    if (this.connection) {
+      return this.connection;
+    }
+
+    if (this.shareConnection && this.sharedConnectionKey) {
+      const sharedConnection =
+        AmqpCacoon.sharedConnections[this.sharedConnectionKey];
+      if (sharedConnection) {
+        sharedConnection.refCount++;
+        this.connection = sharedConnection.connection;
+        return this.connection;
+      }
+    }
+
+    const connection = amqp.connect([this.fullHostName], this.amqp_opts);
+    this.connection = connection;
+
+    if (this.shareConnection && this.sharedConnectionKey) {
+      AmqpCacoon.sharedConnections[this.sharedConnectionKey] = {
+        connection,
+        refCount: 1,
+      };
+    }
+
+    return connection;
+  }
+
+  private async releaseConnection() {
+    const connection = this.connection;
+    if (!connection) return;
+
+    this.removeConnectionEvents(connection);
+
+    if (this.shareConnection && this.sharedConnectionKey) {
+      const sharedConnection =
+        AmqpCacoon.sharedConnections[this.sharedConnectionKey];
+      if (sharedConnection && sharedConnection.connection === connection) {
+        sharedConnection.refCount--;
+        if (sharedConnection.refCount <= 0) {
+          delete AmqpCacoon.sharedConnections[this.sharedConnectionKey];
+          this.connection = undefined;
+          await connection.close();
+          return;
+        }
+        this.connection = undefined;
+        return;
+      }
+    }
+
+    this.connection = undefined;
+    await connection.close();
   }
 
   /**
@@ -169,17 +251,13 @@ class AmqpCacoon {
         return this.pubChannelWrapper;
       }
       // Connect if needed
-      this.connection =
-        this.connection || amqp.connect([this.fullHostName], this.amqp_opts);
-
-      if (this.connection) {
-        this.injectConnectionEvents(this.connection);
-      }
+      const connection = this.getOrCreateConnection();
+      this.injectConnectionEvents(connection);
 
       // Open a channel (get reference to ChannelWrapper)
       // Add a setup function that will be called on each connection retry
       // This function is specified in the config
-      this.pubChannelWrapper = this.connection.createChannel({
+      this.pubChannelWrapper = connection.createChannel({
         setup: (channel: ConfirmChannel) => {
           if (this.onChannelConnect) {
             return this.onChannelConnect(channel);
@@ -206,17 +284,13 @@ class AmqpCacoon {
       // Return the subChannel if we are already connected
       if (this.subChannelWrapper) return this.subChannelWrapper;
       // Connect if needed
-      this.connection =
-        this.connection || amqp.connect([this.fullHostName], this.amqp_opts);
-
-      if (this.connection) {
-        this.injectConnectionEvents(this.connection);
-      }
+      const connection = this.getOrCreateConnection();
+      this.injectConnectionEvents(connection);
 
       // Open a channel (get reference to ChannelWrapper)
       // Add a setup function that will be called on each connection retry
       // This function is specified in the config
-      this.subChannelWrapper = this.connection.createChannel({
+      this.subChannelWrapper = connection.createChannel({
         setup: (channel: ConfirmChannel) => {
           // `channel` here is a regular amqplib `ConfirmChannel`.
           // Note that `this` here is the channelWrapper instance.
@@ -433,9 +507,7 @@ class AmqpCacoon {
     try {
       await this.closePublishChannel();
       await this.closeConsumerChannel();
-      if (this.connection) {
-        return this.connection.close();
-      }
+      await this.releaseConnection();
     } catch (error) {
       // Some unsent messages
     }
@@ -580,7 +652,7 @@ class AmqpCacoon {
     for (let conn of globalThis.amqpCacoonConnections) {
       closeProms.push(conn.close());
     }
-    Promise.all(closeProms);
+    await Promise.all(closeProms);
     globalThis.amqpCacoonConnections?.[0]?.logger?.info(
       "AMQPCacoon.gracefullShutdownAll: END",
     );

--- a/tests/e2e/shutdown.test.ts
+++ b/tests/e2e/shutdown.test.ts
@@ -1,0 +1,379 @@
+import { expect } from "chai";
+import "mocha";
+import { execFileSync } from "child_process";
+
+import AmqpCacoon, {
+  ConfirmChannel,
+  ConsumeMessage,
+  IAmqpCacoonConfig,
+} from "../../src";
+
+const E2E_HOST = process.env.AMQP_E2E_HOST || "127.0.0.1";
+const E2E_PORT = Number(process.env.AMQP_E2E_PORT || "5673");
+const E2E_USERNAME = process.env.AMQP_E2E_USERNAME || "guest";
+const E2E_PASSWORD = process.env.AMQP_E2E_PASSWORD || "guest";
+const CONNECTION_TIMEOUT_MS = 15000;
+const SHUTDOWN_WAIT_ASSERTION_MS = 250;
+const MESSAGE_WAIT_TIMEOUT_MS = 10000;
+const COMPOSE_FILE = "docker-compose.e2e.yml";
+
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function createDeferred() {
+  let resolve!: () => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<void>((innerResolve, innerReject) => {
+    resolve = innerResolve;
+    reject = innerReject;
+  });
+  return { promise, resolve, reject };
+}
+
+async function waitForCondition(
+  predicate: () => boolean | Promise<boolean>,
+  timeoutMs: number,
+  errorMessage: string,
+) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (await predicate()) {
+      return;
+    }
+    await delay(100);
+  }
+
+  throw new Error(errorMessage);
+}
+
+function createQueueName() {
+  return `amqp-cacoon-e2e-shutdown-${Date.now()}-${Math.random()
+    .toString(16)
+    .slice(2)}`;
+}
+
+function createConfig(queue: string): IAmqpCacoonConfig {
+  return {
+    protocol: "amqp",
+    username: E2E_USERNAME,
+    password: E2E_PASSWORD,
+    host: E2E_HOST,
+    port: E2E_PORT,
+    amqp_opts: {
+      heartbeatIntervalInSeconds: 5,
+      reconnectTimeInSeconds: 5,
+      connectionOptions: {},
+    },
+    providers: {},
+    onChannelConnect: async (channel: ConfirmChannel) => {
+      await channel.assertQueue(queue, {
+        durable: false,
+        autoDelete: false,
+      });
+      await channel.prefetch(1);
+    },
+  };
+}
+
+async function waitForRabbitMq(queue: string) {
+  const probe = new AmqpCacoon(createConfig(queue));
+  const startedAt = Date.now();
+  let lastError: unknown;
+
+  try {
+    while (Date.now() - startedAt < CONNECTION_TIMEOUT_MS) {
+      try {
+        const channel = await probe.getPublishChannel();
+        await channel.waitForConnect();
+        return;
+      } catch (error) {
+        lastError = error;
+        await delay(500);
+      }
+    }
+  } finally {
+    await probe.close();
+  }
+
+  throw new Error(
+    `RabbitMQ was not reachable within ${CONNECTION_TIMEOUT_MS}ms. Last error: ${String(lastError)}`,
+  );
+}
+
+function stopRabbitMq() {
+  execFileSync("docker", ["compose", "-f", COMPOSE_FILE, "stop", "rabbitmq"], {
+    cwd: process.cwd(),
+    stdio: "pipe",
+  });
+}
+
+function startRabbitMq() {
+  execFileSync("docker", ["compose", "-f", COMPOSE_FILE, "up", "-d", "rabbitmq"], {
+    cwd: process.cwd(),
+    stdio: "pipe",
+  });
+}
+
+function removeRabbitMq() {
+  execFileSync("docker", ["compose", "-f", COMPOSE_FILE, "down", "-v"], {
+    cwd: process.cwd(),
+    stdio: "pipe",
+  });
+}
+
+describe("Amqp Cacoon E2E", function () {
+  this.timeout(30000);
+
+  let queueName: string;
+  let consumer: AmqpCacoon;
+  let publisher: AmqpCacoon;
+
+  before(async () => {
+    startRabbitMq();
+    await waitForRabbitMq(createQueueName());
+  });
+
+  beforeEach(async () => {
+    queueName = createQueueName();
+    await waitForRabbitMq(queueName);
+    consumer = new AmqpCacoon(createConfig(queueName));
+    publisher = new AmqpCacoon(createConfig(queueName));
+
+    await (await consumer.getConsumerChannel()).waitForConnect();
+    await (await publisher.getPublishChannel()).waitForConnect();
+  });
+
+  afterEach(async () => {
+    startRabbitMq();
+    await waitForRabbitMq(queueName);
+
+    try {
+      const channel = await publisher.getPublishChannel();
+      await channel.waitForConnect();
+      await channel.deleteQueue(queueName);
+    } catch (error) {
+      // Ignore cleanup failures when the connection has already been closed.
+    }
+
+    await Promise.allSettled([consumer?.close(), publisher?.close()]);
+  });
+
+  after(async () => {
+    removeRabbitMq();
+  });
+
+  it("gracefullShutdown waits for an in-flight consumer to finish before closing", async () => {
+    const handlerStarted = createDeferred();
+    const allowHandlerToFinish = createDeferred();
+    const handlerFinished = createDeferred();
+    let shutdownResolved = false;
+    let prePublishCalledBeforeHandlerFinished = false;
+    let preCloseCalledBeforeHandlerFinished = false;
+    let handlerHasFinished = false;
+
+    await consumer.registerConsumer(
+      queueName,
+      async (channel, msg: ConsumeMessage) => {
+        handlerStarted.resolve();
+        await allowHandlerToFinish.promise;
+        channel.ack(msg);
+        handlerHasFinished = true;
+        handlerFinished.resolve();
+      },
+      { noAck: false },
+    );
+
+    await publisher.publish(
+      "",
+      queueName,
+      Buffer.from("shutdown-test-message"),
+    );
+    await handlerStarted.promise;
+
+    const shutdownPromise = consumer
+      .gracefullShutdown({
+        prePublishCallback: async () => {
+          if (!handlerHasFinished) {
+            prePublishCalledBeforeHandlerFinished = true;
+          }
+        },
+        preCloseCallback: async () => {
+          if (!handlerHasFinished) {
+            preCloseCalledBeforeHandlerFinished = true;
+          }
+        },
+      })
+      .then(() => {
+        shutdownResolved = true;
+      });
+
+    await delay(SHUTDOWN_WAIT_ASSERTION_MS);
+    expect(
+      shutdownResolved,
+      "gracefullShutdown resolved before the long-running handler finished",
+    ).to.equal(false);
+    expect(
+      prePublishCalledBeforeHandlerFinished,
+      "prePublishCallback ran before the in-flight handler completed",
+    ).to.equal(false);
+    expect(
+      preCloseCalledBeforeHandlerFinished,
+      "preCloseCallback ran before the in-flight handler completed",
+    ).to.equal(false);
+
+    allowHandlerToFinish.resolve();
+    await handlerFinished.promise;
+    await shutdownPromise;
+
+    expect(
+      prePublishCalledBeforeHandlerFinished,
+      "prePublishCallback should not run until the handler has completed",
+    ).to.equal(false);
+    expect(
+      preCloseCalledBeforeHandlerFinished,
+      "preCloseCallback should not run until the handler has completed",
+    ).to.equal(false);
+    expect(shutdownResolved, "gracefullShutdown never resolved").to.equal(true);
+  });
+
+  it("leaves queued backlog messages on RabbitMQ when shutdown happens during the first in-flight message", async () => {
+    const totalMessages = 10;
+    const handlerStarted = createDeferred();
+    const allowHandlerToFinish = createDeferred();
+    const handlerFinished = createDeferred();
+    let processedMessages = 0;
+
+    await consumer.registerConsumer(
+      queueName,
+      async (channel, msg: ConsumeMessage) => {
+        processedMessages++;
+        handlerStarted.resolve();
+        await allowHandlerToFinish.promise;
+        channel.ack(msg);
+        handlerFinished.resolve();
+      },
+      { noAck: false, prefetch: 1 },
+    );
+
+    for (let i = 0; i < totalMessages; i++) {
+      await publisher.publish(
+        "",
+        queueName,
+        Buffer.from(`shutdown-backlog-message-${i}`),
+      );
+    }
+
+    await handlerStarted.promise;
+
+    const shutdownPromise = consumer.gracefullShutdown({
+      prePublishCallback: async () => Promise.resolve(),
+      preCloseCallback: async () => Promise.resolve(),
+    });
+
+    await delay(SHUTDOWN_WAIT_ASSERTION_MS);
+    expect(
+      processedMessages,
+      "prefetch=1 should only allow the first message to be in flight before shutdown",
+    ).to.equal(1);
+
+    allowHandlerToFinish.resolve();
+    await handlerFinished.promise;
+    await shutdownPromise;
+
+    const publisherChannel = await publisher.getPublishChannel();
+    await publisherChannel.waitForConnect();
+    const queueState = await publisherChannel.checkQueue(queueName);
+
+    expect(
+      processedMessages,
+      "only the first in-flight message should have been processed",
+    ).to.equal(1);
+    expect(
+      queueState.messageCount,
+      "the remaining backlog should still be present on the queue after shutdown",
+    ).to.equal(totalMessages - 1);
+  });
+
+  it("reconnects a consumer and resumes message delivery after RabbitMQ restarts", async () => {
+    const receivedMessages: Array<string> = [];
+    const messageAfterRestart = createDeferred();
+
+    await consumer.registerConsumer(
+      queueName,
+      async (channel, msg: ConsumeMessage) => {
+        const payload = msg.content.toString();
+        receivedMessages.push(payload);
+        channel.ack(msg);
+        if (payload === "after-restart") {
+          messageAfterRestart.resolve();
+        }
+      },
+      { noAck: false, prefetch: 1 },
+    );
+
+    await publisher.publish("", queueName, Buffer.from("before-restart"));
+    await waitForCondition(
+      () => receivedMessages.includes("before-restart"),
+      MESSAGE_WAIT_TIMEOUT_MS,
+      "consumer did not receive the message before broker restart",
+    );
+
+    stopRabbitMq();
+    await delay(1000);
+    startRabbitMq();
+    await waitForRabbitMq(queueName);
+
+    const postRestartPublisher = new AmqpCacoon(createConfig(queueName));
+    try {
+      const channel = await postRestartPublisher.getPublishChannel();
+      await channel.waitForConnect();
+      await postRestartPublisher.publish("", queueName, Buffer.from("after-restart"));
+      await messageAfterRestart.promise;
+    } finally {
+      await postRestartPublisher.close();
+    }
+
+    expect(receivedMessages, "consumer did not resume after reconnect").to.deep.equal([
+      "before-restart",
+      "after-restart",
+    ]);
+  });
+
+  it("publishes queued messages after RabbitMQ reconnects", async () => {
+    stopRabbitMq();
+    await delay(1000);
+
+    const queuedPublish = publisher.publish(
+      "",
+      queueName,
+      Buffer.from("published-during-outage"),
+    );
+
+    startRabbitMq();
+    await waitForRabbitMq(queueName);
+    await queuedPublish;
+
+    const verifier = new AmqpCacoon(createConfig(queueName));
+    try {
+      const channel = await verifier.getPublishChannel();
+      await channel.waitForConnect();
+      await waitForCondition(
+        async () => {
+          const queueState = await channel.checkQueue(queueName);
+          return queueState.messageCount === 1;
+        },
+        MESSAGE_WAIT_TIMEOUT_MS,
+        "queued publish was not delivered after broker reconnect",
+      );
+
+      const queueState = await channel.checkQueue(queueName);
+      expect(
+        queueState.messageCount,
+        "expected the offline publish to be present after reconnect",
+      ).to.equal(1);
+    } finally {
+      await verifier.close();
+    }
+  });
+});

--- a/tests/e2e/shutdown.test.ts
+++ b/tests/e2e/shutdown.test.ts
@@ -76,6 +76,13 @@ function createConfig(queue: string): IAmqpCacoonConfig {
   };
 }
 
+function createSharedConfig(queue: string): IAmqpCacoonConfig {
+  return {
+    ...createConfig(queue),
+    shareConnection: true,
+  };
+}
+
 async function waitForRabbitMq(queue: string) {
   const probe = new AmqpCacoon(createConfig(queue));
   const startedAt = Date.now();
@@ -157,12 +164,26 @@ describe("Amqp Cacoon E2E", function () {
     }
 
     await Promise.allSettled([consumer?.close(), publisher?.close()]);
+    globalThis.amqpCacoonConnections = [];
+    (AmqpCacoon as any).sharedConnections = {};
   });
 
   after(async () => {
     removeRabbitMq();
   });
 
+  /**
+   * Verifies the core graceful shutdown contract for a normal consumer.
+   * We need this because shutdown correctness depends on waiting for in-flight work
+   * instead of closing channels underneath a still-running handler.
+   *
+   * Steps:
+   * 1. Register a consumer whose handler blocks until the test releases it.
+   * 2. Publish one message and wait until the handler has started.
+   * 3. Trigger `gracefullShutdown()`.
+   * 4. Assert shutdown does not resolve while the handler is still blocked.
+   * 5. Release the handler and assert shutdown then completes.
+   */
   it("gracefullShutdown waits for an in-flight consumer to finish before closing", async () => {
     const handlerStarted = createDeferred();
     const allowHandlerToFinish = createDeferred();
@@ -237,6 +258,19 @@ describe("Amqp Cacoon E2E", function () {
     expect(shutdownResolved, "gracefullShutdown never resolved").to.equal(true);
   });
 
+  /**
+   * Verifies backlog behavior during shutdown when `prefetch: 1` is in use.
+   * We need this because the expected operational behavior is that only the
+   * in-flight message is processed, while the remaining queued backlog stays on RabbitMQ.
+   *
+   * Steps:
+   * 1. Register a blocking consumer with `prefetch: 1`.
+   * 2. Publish ten messages to create a backlog.
+   * 3. Wait until only the first message is in-flight.
+   * 4. Trigger graceful shutdown while that first handler is blocked.
+   * 5. Release the handler, let shutdown complete, and inspect the queue.
+   * 6. Assert one message was processed and the other nine remain queued.
+   */
   it("leaves queued backlog messages on RabbitMQ when shutdown happens during the first in-flight message", async () => {
     const totalMessages = 10;
     const handlerStarted = createDeferred();
@@ -295,6 +329,18 @@ describe("Amqp Cacoon E2E", function () {
     ).to.equal(totalMessages - 1);
   });
 
+  /**
+   * Verifies consumer recovery after a real broker restart.
+   * We need this because reconnecting and resubscribing consumers is one of the
+   * primary guarantees this wrapper is expected to provide in production.
+   *
+   * Steps:
+   * 1. Register a consumer and prove it receives a message before restart.
+   * 2. Stop RabbitMQ to break the underlying connection.
+   * 3. Start RabbitMQ again and wait for the broker to become reachable.
+   * 4. Publish another message after restart.
+   * 5. Assert the original consumer resumes and receives the post-restart message.
+   */
   it("reconnects a consumer and resumes message delivery after RabbitMQ restarts", async () => {
     const receivedMessages: Array<string> = [];
     const messageAfterRestart = createDeferred();
@@ -340,6 +386,18 @@ describe("Amqp Cacoon E2E", function () {
     ]);
   });
 
+  /**
+   * Verifies publish buffering across a broker outage.
+   * We need this because callers rely on queued publishes surviving short outages
+   * and being delivered after the connection manager reconnects.
+   *
+   * Steps:
+   * 1. Stop RabbitMQ before publishing.
+   * 2. Call `publish()` while the broker is unavailable.
+   * 3. Start RabbitMQ again and wait for reconnect.
+   * 4. Wait for the queued publish promise to settle successfully.
+   * 5. Inspect the queue and assert the message was eventually delivered.
+   */
   it("publishes queued messages after RabbitMQ reconnects", async () => {
     stopRabbitMq();
     await delay(1000);
@@ -374,6 +432,145 @@ describe("Amqp Cacoon E2E", function () {
       ).to.equal(1);
     } finally {
       await verifier.close();
+    }
+  });
+
+  /**
+   * Verifies the minimal shared-connection mode actually shares one underlying connection.
+   * We need this because the feature is only useful if matching instances reuse the same
+   * `AmqpConnectionManager` rather than silently creating parallel connections.
+   *
+   * Steps:
+   * 1. Create two matching instances with `shareConnection: true`.
+   * 2. Open channels on both instances.
+   * 3. Assert both instances point at the same underlying connection object.
+   */
+  it("reuses the same underlying connection for matching shared instances", async () => {
+    const sharedPublisher = new AmqpCacoon(createSharedConfig(queueName));
+    const sharedConsumer = new AmqpCacoon(createSharedConfig(queueName));
+
+    try {
+      await (await sharedPublisher.getPublishChannel()).waitForConnect();
+      await (await sharedConsumer.getConsumerChannel()).waitForConnect();
+
+      expect(
+        (sharedPublisher as any).connection,
+        "shared instances should reuse the same AmqpConnectionManager",
+      ).to.equal((sharedConsumer as any).connection);
+    } finally {
+      await Promise.allSettled([sharedPublisher.close(), sharedConsumer.close()]);
+    }
+  });
+
+  /**
+   * Verifies shared connection ref-counting during close.
+   * We need this because one sharer closing should not tear down the shared connection
+   * while another instance is still using it.
+   *
+   * Steps:
+   * 1. Create two matching shared instances.
+   * 2. Register a consumer on one shared instance.
+   * 3. Close the other shared instance.
+   * 4. Publish a message through an independent publisher.
+   * 5. Assert the remaining shared consumer still receives and processes the message.
+   */
+  it("keeps the remaining shared instance usable after another sharer closes", async () => {
+    const sharedPublisher = new AmqpCacoon(createSharedConfig(queueName));
+    const sharedConsumer = new AmqpCacoon(createSharedConfig(queueName));
+    const receivedMessage = createDeferred();
+
+    try {
+      await (await sharedPublisher.getPublishChannel()).waitForConnect();
+      await (await sharedConsumer.getConsumerChannel()).waitForConnect();
+
+      await sharedConsumer.registerConsumer(
+        queueName,
+        async (channel, msg: ConsumeMessage) => {
+          channel.ack(msg);
+          receivedMessage.resolve();
+        },
+        { noAck: false, prefetch: 1 },
+      );
+
+      await sharedPublisher.close();
+      await publisher.publish(
+        "",
+        queueName,
+        Buffer.from("message-after-other-sharer-closed"),
+      );
+      await receivedMessage.promise;
+    } finally {
+      await Promise.allSettled([sharedPublisher.close(), sharedConsumer.close()]);
+    }
+  });
+
+  /**
+   * Verifies `gracefullShutdownAll()` interacts correctly with shared connections.
+   * We need this because shared ownership adds ref-counting and a global shutdown must
+   * still wait for in-flight work before releasing the final shared connection.
+   *
+   * Steps:
+   * 1. Create shared publisher and consumer instances.
+   * 2. Register a blocking consumer handler on the shared consumer.
+   * 3. Publish one message and wait until the handler has started.
+   * 4. Trigger `gracefullShutdownAll()`.
+   * 5. Assert global shutdown does not resolve while the shared handler is still blocked.
+   * 6. Release the handler and assert shutdown completes and shared state is cleaned up.
+   */
+  it("gracefullShutdownAll waits for in-flight shared consumers before closing the shared connection", async () => {
+    const sharedConsumer = new AmqpCacoon(createSharedConfig(queueName));
+    const sharedPublisher = new AmqpCacoon(createSharedConfig(queueName));
+    const handlerStarted = createDeferred();
+    const allowHandlerToFinish = createDeferred();
+    const handlerFinished = createDeferred();
+    let shutdownResolved = false;
+
+    try {
+      await (await sharedConsumer.getConsumerChannel()).waitForConnect();
+      await (await sharedPublisher.getPublishChannel()).waitForConnect();
+
+      await sharedConsumer.registerConsumer(
+        queueName,
+        async (channel, msg: ConsumeMessage) => {
+          handlerStarted.resolve();
+          await allowHandlerToFinish.promise;
+          channel.ack(msg);
+          handlerFinished.resolve();
+        },
+        { noAck: false, prefetch: 1 },
+      );
+
+      await publisher.publish("", queueName, Buffer.from("shared-shutdown-message"));
+      await handlerStarted.promise;
+
+      const shutdownPromise = AmqpCacoon.gracefullShutdownAll({
+        softwareBlockCanceledConsumers: false,
+        prePublishCallback: async () => Promise.resolve(),
+        preCloseCallback: async () => Promise.resolve(),
+      }).then(() => {
+        shutdownResolved = true;
+      });
+
+      await delay(SHUTDOWN_WAIT_ASSERTION_MS);
+      expect(
+        shutdownResolved,
+        "gracefullShutdownAll resolved before the shared in-flight handler finished",
+      ).to.equal(false);
+
+      allowHandlerToFinish.resolve();
+      await handlerFinished.promise;
+      await shutdownPromise;
+
+      expect(
+        shutdownResolved,
+        "gracefullShutdownAll should resolve after the shared in-flight handler finishes",
+      ).to.equal(true);
+      expect(
+        (AmqpCacoon as any).sharedConnections,
+        "shared connection registry should be empty after shared shutdown completes",
+      ).to.deep.equal({});
+    } finally {
+      await Promise.allSettled([sharedPublisher.close(), sharedConsumer.close()]);
     }
   });
 });

--- a/tests/unit/amqp-cacoon.test.ts
+++ b/tests/unit/amqp-cacoon.test.ts
@@ -225,17 +225,18 @@ describe("Amqp Cacoon", () => {
       // MOCK amqpCacoon.registerConsumerPrivate since that's as deep as we can go before
       // going inside AMQP Connection Manager or AMQPLIB which we're not testing
       simple.mock(amqpCacoon, "registerConsumerPrivate").callOriginal();
-      // MOCK channel.addSetup since that runs, connects to AMQP, then makes a callback to our consumer!
-      // Which we'll just MOCK
-      simple.mock(channelWrapper, "addSetup").resolveWith(channelWrapper);
+      // MOCK channel.consume since that is the wrapper API used to register consumers
+      simple.mock(channelWrapper, "consume").resolveWith({
+        consumerTag: consumerOptions.consumerTag,
+      });
       // Setup the name for a queue. Not important, just needs to be a string
       const queue = "someQueue";
       // Now register the consumer
       await amqpCacoon.registerConsumer(queue, handler, consumerOptions);
-      // Check to make addSetup was called
+      // Check to make consume was called
       expect(
-        channelWrapper.addSetup.callCount,
-        "addSetup was not called!",
+        channelWrapper.consume.callCount,
+        "consume was not called!",
       ).to.equal(1);
       // Let's check that 'registerConsumerPrivate' was passed the right things
       expect(
@@ -288,9 +289,10 @@ describe("Amqp Cacoon", () => {
       // MOCK amqpCacoon.registerConsumerPrivate since that's as deep as we can go before
       // going inside AMQP Connection Manager or AMQPLIB which we're not testing
       simple.mock(amqpCacoon, "registerConsumerPrivate").callOriginal();
-      // MOCK channel.addSetup since that runs, connects to AMQP, then makes a callback to our consumer!
-      // Which we'll just MOCK
-      simple.mock(channelWrapper, "addSetup").resolveWith(channelWrapper);
+      // MOCK channel.consume since that is the wrapper API used to register consumers
+      simple.mock(channelWrapper, "consume").resolveWith({
+        consumerTag: consumerBatchOptions.consumerTag,
+      });
       // Setup the name for a queue. Not important, just needs to be a string
       const queue = "someQueue";
       // Now register the consumer
@@ -299,10 +301,10 @@ describe("Amqp Cacoon", () => {
         handler,
         consumerBatchOptions,
       );
-      // Check to make addSetup was called
+      // Check to make consume was called
       expect(
-        channelWrapper.addSetup.callCount,
-        "addSetup was not called!",
+        channelWrapper.consume.callCount,
+        "consume was not called!",
       ).to.equal(1);
       // Let's check that 'registerConsumerPrivate' was passed the right things
       expect(

--- a/tests/unit/amqp-cacoon.test.ts
+++ b/tests/unit/amqp-cacoon.test.ts
@@ -6,6 +6,7 @@
 import { expect } from "chai";
 import "mocha";
 import simple from "simple-mock";
+import amqp from "amqp-connection-manager";
 import AmqpCacoon, {
   IAmqpCacoonConfig,
   ChannelWrapper,
@@ -64,6 +65,8 @@ describe("Amqp Cacoon", () => {
   afterEach(() => {
     // After each test, clear out any MOCKs.
     simple.restore();
+    globalThis.amqpCacoonConnections = [];
+    (AmqpCacoon as any).sharedConnections = {};
   });
 
   // Just make sure it initializes
@@ -320,5 +323,129 @@ describe("Amqp Cacoon", () => {
     } catch (e) {
       throw e;
     }
+  });
+
+  it("reuses the first matching shared connection", async () => {
+    const sharedConnection = {
+      on: () => sharedConnection,
+      removeListener: () => sharedConnection,
+      createChannel: () => undefined,
+      close: () => Promise.resolve(undefined),
+    };
+    simple.mock(sharedConnection, "createChannel").returnWith(
+      { close: async () => {} } as any,
+      { close: async () => {} } as any,
+    );
+    simple.mock(sharedConnection, "close").resolveWith(undefined);
+
+    simple.mock(amqp, "connect").returnWith(sharedConnection as any);
+
+    const sharedConfig = {
+      ...amqpCacoonConfig,
+      shareConnection: true,
+    };
+    const first = new AmqpCacoon(sharedConfig);
+    const second = new AmqpCacoon(sharedConfig);
+
+    await first.getPublishChannel();
+    await second.getPublishChannel();
+
+    expect((amqp.connect as any).callCount, "expected a single shared connect").to.equal(1);
+    expect((first as any).connection, "first instance did not retain shared connection").to.equal(
+      sharedConnection,
+    );
+    expect((second as any).connection, "second instance did not reuse shared connection").to.equal(
+      sharedConnection,
+    );
+  });
+
+  it("only closes a shared connection when the last sharer closes", async () => {
+    const firstWrapper = { closeCallCount: 0, close: async () => undefined };
+    const secondWrapper = { closeCallCount: 0, close: async () => undefined };
+    firstWrapper.close = async () => {
+      firstWrapper.closeCallCount++;
+    };
+    secondWrapper.close = async () => {
+      secondWrapper.closeCallCount++;
+    };
+    let createChannelCallCount = 0;
+    const sharedConnection = {
+      on: () => sharedConnection,
+      removeListener: () => sharedConnection,
+      createChannel: () => {
+        createChannelCallCount++;
+        return createChannelCallCount === 1 ? firstWrapper : secondWrapper;
+      },
+      close: () => Promise.resolve(undefined),
+    };
+    simple.mock(sharedConnection, "close").resolveWith(undefined);
+
+    simple.mock(amqp, "connect").returnWith(sharedConnection as any);
+
+    const sharedConfig = {
+      ...amqpCacoonConfig,
+      shareConnection: true,
+    };
+    const first = new AmqpCacoon(sharedConfig);
+    const second = new AmqpCacoon(sharedConfig);
+
+    await first.getPublishChannel();
+    await second.getPublishChannel();
+
+    await first.close();
+    expect(sharedConnection.close.callCount, "shared connection closed too early").to.equal(0);
+
+    await second.close();
+    expect(sharedConnection.close.callCount, "shared connection should close once").to.equal(1);
+    expect(firstWrapper.closeCallCount, "first wrapper should be closed").to.equal(1);
+    expect(secondWrapper.closeCallCount, "second wrapper should be closed").to.equal(1);
+  });
+
+  it("gracefullShutdownAll waits for all close calls to finish", async () => {
+    let resolveFirstClose = () => undefined;
+    let resolveSecondClose = () => undefined;
+    let shutdownResolved = false;
+    const firstClosePromise = new Promise<void>((resolve) => {
+      resolveFirstClose = resolve;
+    });
+    const secondClosePromise = new Promise<void>((resolve) => {
+      resolveSecondClose = resolve;
+    });
+
+    globalThis.amqpCacoonConnections = [
+      {
+        logger: undefined,
+        messageStatistics: {},
+        cancelConsumerChanel: async () => Promise.resolve(),
+        cancelPublisherChanel: async () => Promise.resolve(),
+        close: () => firstClosePromise,
+      },
+      {
+        logger: undefined,
+        messageStatistics: {},
+        cancelConsumerChanel: async () => Promise.resolve(),
+        cancelPublisherChanel: async () => Promise.resolve(),
+        close: () => secondClosePromise,
+      },
+    ] as any;
+
+    const shutdownPromise = AmqpCacoon.gracefullShutdownAll({
+      softwareBlockCanceledConsumers: false,
+      prePublishCallback: async () => Promise.resolve(),
+      preCloseCallback: async () => Promise.resolve(),
+    }).then(() => {
+      shutdownResolved = true;
+    });
+
+    await Promise.resolve();
+    expect(shutdownResolved, "shutdown resolved before close promises completed").to.equal(false);
+
+    resolveFirstClose();
+    await Promise.resolve();
+    expect(shutdownResolved, "shutdown resolved before all closes completed").to.equal(false);
+
+    resolveSecondClose();
+    await shutdownPromise;
+    expect(shutdownResolved, "shutdown did not wait for all closes").to.equal(true);
   });
 });


### PR DESCRIPTION
# Summary

  This PR improves AMQP consumer shutdown behavior, adds optional shared
  connection support, and introduces real RabbitMQ end-to-end coverage for
  shutdown and reconnect scenarios.

# What changed

  - Switched consumer registration to use ChannelWrapper.consume() instead of
    raw channel.consume()
  - Fixed consumer cancellation so cancelAll() works with consumers created by
    this library
  - Added optional shareConnection?: boolean support
  - Implemented shared AmqpConnectionManager reuse for matching shared instances
  - Added ref-counted shared connection cleanup so one sharer closing does not
    tear down the connection for others
  - Fixed gracefullShutdownAll() to actually await all close() calls
  - Added Docker-backed e2e coverage against real RabbitMQ
  - Made npm run test:e2e self-contained by starting and tearing down RabbitMQ
    automatically
  - Added explanatory comment blocks above each e2e test describing purpose and
    step-by-step flow

# E2E coverage added

  - Graceful shutdown waits for an in-flight consumer before closing
  - Backlog remains queued during shutdown with prefetch: 1
  - Consumer reconnects and resumes after RabbitMQ restart
  - Queued publishes are delivered after reconnect
  - Matching shared instances reuse the same underlying connection
  - Closing one shared instance does not break the remaining sharer
  - gracefullShutdownAll() works correctly with shared connections and waits for
    in-flight work

# Why

  - The previous consumer registration path bypassed amqp-connection-manager’s
    consumer tracking, which made cancel semantics unreliable
  - Shared connection support reduces duplicate underlying connections while
    preserving per-instance channels
  - The new e2e suite validates the lifecycle behavior this wrapper is expected
    to guarantee in production

  Validation

  - npm test
  - npm run test:e2e
